### PR TITLE
fix: fix deploy to use production in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "babel:compile": "yarn babel src/js/**/*.js --out-dir lib --source-maps inline",
     "babel:watch": "yarn babel src/js/**/*.js --watch --out-dir lib --source-maps inline",
-    "deploy": "NODE_ENV=production yarn webpack",
+    "deploy": "yarn webpack --mode=production",
     "dev:ignore:all": "run-p dev:ignore:*:cat",
     "// HACK dev:ignore:all:sanitize": "& : を加えたのは，lint-staged からくるファイル名の引数を排除するため(& : path/to/file)",
     "dev:ignore:all:sanitize": "yarn dev:ignore:all & : ",


### PR DESCRIPTION
## to use `yarn deploy` npm-scripts

### why

it does not move in bash environment
